### PR TITLE
Change Modernizr file

### DIFF
--- a/dists/base/base-d7-modules.make
+++ b/dists/base/base-d7-modules.make
@@ -213,6 +213,6 @@ libraries[underscore][type] = "library"
 
 ; Modernizr (navbar)
 libraries[modernizr][download][type] = "get"
-libraries[modernizr][download][url] = "http://modernizr.com/downloads/modernizr-latest.js"
+libraries[modernizr][download][url] = "http://modernizr.com/downloads/modernizr.js"
 libraries[modernizr][directory_name] = "modernizr"
 libraries[modernizr][type] = "library"


### PR DESCRIPTION
Download the `modernizr.js` instead of latest, the code is the same, but the downloaded file name will be correct and detected by the *libraries* module.