### PR TITLE
add maillog module to development

### DIFF
--- a/dists/base/base-d7-modules.make
+++ b/dists/base/base-d7-modules.make
@@ -13,6 +13,7 @@ projects[devel][subdir] = "development"
 projects[devel_themer][subdir] = "development"
 projects[stage_file_proxy][subdir] = "development"
 projects[diff][subdir] = "development"
+projects[maillog][subdir] = "development"
 
 ; BACKUP
 projects[backup_migrate][subdir] = "contrib"


### PR DESCRIPTION
We should use that in development - I guess. It is already part of the reconfig script and driving me nuts, that I always have to move it after running reconfig in a new platform :)